### PR TITLE
Fix Hero Nav re-render hack

### DIFF
--- a/src/app/components/FixedNavSection.tsx
+++ b/src/app/components/FixedNavSection.tsx
@@ -11,7 +11,6 @@ const FixedNavSection = ({ children, setIsNavFixed }: FixedNavSectionProps) => {
   const isInView = useInView(fixedNavSectionRef, { amount: 0.5 });
 
   useEffect(() => {
-    console.log('fixed nav section', isInView);
     setIsNavFixed(isInView);
   }, [isInView, setIsNavFixed]);
 

--- a/src/app/components/Hero.tsx
+++ b/src/app/components/Hero.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect } from "react";
+import { useRef, useEffect, useCallback } from "react";
 import Image from "next/image";
 import { homepage_hero_photos } from "@/app/utils/lists";
 import { Swiper, SwiperSlide } from "swiper/react";
@@ -19,12 +19,13 @@ const Hero = ({ setIsNavFixed }: HeroProps) => {
   const y = useTransform(scrollYProgress, [0, 1], ["0%", "50%"]);
   const counter = useRef(0);
 
+  const fixNav = useCallback(() => {
+    setIsNavFixed(false);
+  }, [setIsNavFixed, setIsNavFixed]);
+
   useEffect(() => {
-    // TODO: Fix hacky solution to prevent flickering
-    counter.current++;
-    if (counter.current < 3) return;
-    setIsNavFixed(!isInView);
-  }, [isInView, setIsNavFixed]);
+    fixNav();
+  }, [fixNav]);
 
   return (
     <motion.div


### PR DESCRIPTION
Remove the counter that prevented Nav re-renders when checking isInView in Hero