### PR TITLE
Fix hero sections cut off by mobile browser chrome

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -68,7 +68,7 @@ export default function ContactPage() {
   return (
     <main className="bg-black min-h-screen">
       {/* Hero */}
-      <section className="relative h-screen flex items-end justify-start pb-16 md:pb-24 px-8 md:px-24">
+      <section className="relative h-[100dvh] flex items-end justify-start pb-28 md:pb-24 px-8 md:px-24">
         <Image
           src="/Signature%20Theaters-09073.jpg"
           alt="Signature Theaters contact"

--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -14,7 +14,7 @@ export default function ProductsPage() {
   return (
     <main className="bg-black min-h-screen">
       {/* Hero */}
-      <section className="relative h-screen flex items-end justify-start pb-16 md:pb-24 px-8 md:px-24">
+      <section className="relative h-[100dvh] flex items-end justify-start pb-28 md:pb-24 px-8 md:px-24">
         <Image
           src="/Signature%20Theaters-09804.jpg"
           alt="Signature Theaters luxury products"

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -20,7 +20,7 @@ export default function ProjectsPage() {
   return (
     <main className="bg-black min-h-screen">
       {/* Minimal dark hero */}
-      <section className="h-screen flex items-end justify-start pb-16 md:pb-24 px-8 md:px-24 bg-black grid-background">
+      <section className="h-[100dvh] flex items-end justify-start pb-28 md:pb-24 px-8 md:px-24 bg-black grid-background">
         <div>
           <motion.p
             initial={{ opacity: 0, y: 20 }}

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -14,7 +14,7 @@ export default function ServicesPage() {
   return (
     <main className="bg-black min-h-screen">
       {/* Hero */}
-      <section className="relative h-screen flex items-end justify-start pb-16 md:pb-24 px-8 md:px-24">
+      <section className="relative h-[100dvh] flex items-end justify-start pb-28 md:pb-24 px-8 md:px-24">
         <Image
           src="/Signature%20Theaters-01642.jpg"
           alt="Signature Theaters luxury installation"


### PR DESCRIPTION
Switch h-screen (100vh) to h-[100dvh] and increase mobile bottom padding from pb-16 to pb-28 on all secondary page heroes so content clears persistent browser navigation bars on Android/iOS.